### PR TITLE
Work with clojure 1.10.0 ns spec

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kirasystems/saml20-clj "0.1.13-SNAPSHOT"
+(defproject juji/saml20-clj "0.1.13"
   :description "Basic SAML 2.0 library for SSO."
   :url "https://github.com/k2n/saml20-clj"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject juji/saml20-clj "0.1.13"
+(defproject kirasystems/saml20-clj "0.1.13"
   :description "Basic SAML 2.0 library for SSO."
   :url "https://github.com/k2n/saml20-clj"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -4,22 +4,22 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :source-paths ["src"]
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clj-time "0.11.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [clj-time "0.15.1"]
                  [ring "1.4.0"]
-                 [org.apache.santuario/xmlsec "2.0.4"]
-                 [compojure "1.5.0"]
+                 [org.apache.santuario/xmlsec "2.1.2"]
+                 [compojure "1.6.1"]
                  [org.opensaml/opensaml "2.6.4"]
-                 [org.clojure/data.xml "0.0.7"]
-                 [org.clojure/data.codec "0.1.0"]
-                 [org.clojure/data.zip "0.1.1"]
-                 [org.vlacs/helmsman "1.0.0-alpha5"]]
+                 [org.clojure/data.xml "0.0.8"]
+                 [org.clojure/data.codec "0.1.1"]
+                 [org.clojure/data.zip "0.1.2"]
+                 [org.vlacs/helmsman "1.0.0"]]
   :pedantic :warn
   :profiles {:dev {:source-paths ["dev" "test"]
-                   :dependencies [[org.clojure/tools.namespace "0.2.10"]
-                                  [org.clojure/tools.nrepl "0.2.3"]
+                   :dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
                                   [hiccup "1.0.5"]
-                                  [http-kit "2.1.18"]]}}
+                                  [http-kit "2.3.0"]]}}
   :repositories [["releases" {:url "https://clojars.org/repo"
                               :sign-releases false
                               :username :env

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :source-paths ["src"]
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [clj-time "0.15.1"]
-                 [ring "1.4.0"]
+                 [ring "1.7.1"]
                  [org.apache.santuario/xmlsec "2.1.2"]
                  [compojure "1.6.1"]
                  [org.opensaml/opensaml "2.6.4"]

--- a/src/saml20_clj/sp.clj
+++ b/src/saml20_clj/sp.clj
@@ -8,15 +8,12 @@
             [saml20-clj.shared :as shared]
             [saml20-clj.xml :as saml-xml]
             [clojure.data.zip.xml :as zf])
-  (:import [javax.xml.crypto]
-           [javax.xml.crypto.dsig XMLSignature XMLSignatureFactory]
-           [javax.xml.crypto.dom]
+  (:import [javax.xml.crypto.dsig XMLSignature XMLSignatureFactory]
            [org.apache.xml.security Init]
            [org.apache.xml.security.utils Constants ElementProxy]
            [org.apache.xml.security.transforms Transforms]
            [org.apache.xml.security.c14n Canonicalizer]
            [javax.xml.crypto.dsig.dom DOMValidateContext]
-           [java.security]
            [javax.xml.parsers DocumentBuilderFactory]
            [org.w3c.dom Document]
            [org.w3c.dom NodeList])

--- a/src/saml20_clj/sp.clj
+++ b/src/saml20_clj/sp.clj
@@ -60,6 +60,8 @@
           [:ds:KeyInfo  {:xmlns:ds  "http://www.w3.org/2000/09/xmldsig#"}
            [:ds:X509Data
             [:ds:X509Certificate certificate-str]]]]
+         [:md:SingleLogoutService  {:Binding  "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" 
+                                    :Location  "https://example.org/saml/SingleLogout"}]
          [:md:NameIDFormat "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"]
          [:md:NameIDFormat "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"]
          [:md:NameIDFormat "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]

--- a/src/saml20_clj/sp.clj
+++ b/src/saml20_clj/sp.clj
@@ -44,12 +44,12 @@
    (str
      (hiccup.page/xml-declaration "UTF-8")
      (hiccup/html
-       [:md:EntityDescriptor {:xmlns:md  "urn:oasis:names:tc:SAML:2.0:metadata",
-                              :ID  (clojure.string/replace acs-uri #"[:/]" "_") ,
+       [:md:EntityDescriptor {:xmlns:md  "urn:oasis:names:tc:SAML:2.0:metadata"
+                              :ID  (clojure.string/replace acs-uri #"[:/]" "_")
                               :entityID  app-name}
         [:md:SPSSODescriptor
-         (cond-> {:AuthnRequestsSigned "true",
-                  :WantAssertionsSigned "true",
+         (cond-> {:AuthnRequestsSigned "true"
+                  :WantAssertionsSigned "true"
                   :protocolSupportEnumeration "urn:oasis:names:tc:SAML:2.0:protocol"}
                  (not sign-request?) (dissoc :AuthnRequestsSigned))
          [:md:KeyDescriptor  {:use  "signing"}
@@ -60,12 +60,15 @@
           [:ds:KeyInfo  {:xmlns:ds  "http://www.w3.org/2000/09/xmldsig#"}
            [:ds:X509Data
             [:ds:X509Certificate certificate-str]]]]
-         [:md:NameIDFormat  "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"]
-         [:md:NameIDFormat  "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"]
-         [:md:NameIDFormat  "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]
-         [:md:NameIDFormat  "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"]
-         [:md:NameIDFormat  "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName"]
-         [:md:AssertionConsumerService  {:Binding  "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST", :Location acs-uri, :index  "0", :isDefault  "true"}]]])))
+         [:md:NameIDFormat "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"]
+         [:md:NameIDFormat "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"]
+         [:md:NameIDFormat "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]
+         [:md:NameIDFormat "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"]
+         [:md:NameIDFormat "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName"]
+         [:md:AssertionConsumerService {:Binding  "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                        :Location acs-uri
+                                        :index "0"
+                                        :isDefault "true"}]]])))
   ([app-name acs-uri certificate-str]
    (metadata app-name acs-uri certificate-str true)))
 
@@ -87,10 +90,7 @@
         :AssertionConsumerServiceURL acs-url}
        [:saml:Issuer
         {:xmlns:saml "urn:oasis:names:tc:SAML:2.0:assertion"}
-        saml-service-name]
-       ;;[:samlp:NameIDPolicy {:AllowCreate false :Format saml-format}]
-       
-       ])))
+        saml-service-name]])))
 
 (defn generate-mutables
   []
@@ -114,7 +114,7 @@
      (let [current-time (ctime/now)
            new-saml-id (next-saml-id-fn!)
            issue-instant (shared/make-issue-instant current-time)
-           new-request (create-request issue-instant 
+           new-request (create-request issue-instant
                                        saml-format
                                        saml-service-name
                                        new-saml-id
@@ -182,7 +182,6 @@
         parsed-zipper (clojure.zip/xml-zip xml)]
     (response->map parsed-zipper)))
 
-
 (defn make-saml-signer
   [keystore-filename keystore-password key-alias & {:keys [algorithm] :or {algorithm :sha1}}]
   (when keystore-filename
@@ -206,7 +205,7 @@
               transforms (doto (new Transforms xmldoc)
                            (.addTransform Transforms/TRANSFORM_ENVELOPED_SIGNATURE)
                            (.addTransform Transforms/TRANSFORM_C14N_EXCL_OMIT_COMMENTS))
-              sig (new org.apache.xml.security.signature.XMLSignature xmldoc nil sig-algo 
+              sig (new org.apache.xml.security.signature.XMLSignature xmldoc nil sig-algo
                        Canonicalizer/ALGO_ID_C14N_EXCL_OMIT_COMMENTS)
               canonicalizer (Canonicalizer/getInstance Canonicalizer/ALGO_ID_C14N_EXCL_OMIT_COMMENTS)]
           (.. xmldoc
@@ -223,7 +222,7 @@
   (when keystore-filename
     (let [ks (shared/load-key-store keystore-filename keystore-password)
           private-key (.getKey ks key-alias (.toCharArray keystore-password))
-          decryption-cred (doto (new org.opensaml.xml.security.x509.BasicX509Credential) 
+          decryption-cred (doto (new org.opensaml.xml.security.x509.BasicX509Credential)
                             (.setPrivateKey private-key))
           decrypter (new org.opensaml.saml2.encryption.Decrypter
                          nil
@@ -287,7 +286,7 @@
   (let [status (.. saml-resp getStatus getStatusCode getValue)]
     {:inResponseTo (.getInResponseTo saml-resp)
      :status status
-     :success? (= status org.opensaml.saml2.core.StatusCode/SUCCESS_URI) 
+     :success? (= status org.opensaml.saml2.core.StatusCode/SUCCESS_URI)
      :version (.. saml-resp getVersion toString)
      :issueInstant (to-timestamp (.getIssueInstant saml-resp))
      :destination (.getDestination saml-resp)}))

--- a/src/saml20_clj/sp.clj
+++ b/src/saml20_clj/sp.clj
@@ -60,7 +60,6 @@
           [:ds:KeyInfo  {:xmlns:ds  "http://www.w3.org/2000/09/xmldsig#"}
            [:ds:X509Data
             [:ds:X509Certificate certificate-str]]]]
-         [:md:SingleLogoutService  {:Binding  "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST", :Location  "https://example.org/saml/SingleLogout"}]
          [:md:NameIDFormat  "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"]
          [:md:NameIDFormat  "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"]
          [:md:NameIDFormat  "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]


### PR DESCRIPTION
Otherwise, will get this error:

#error {
 :cause Call to clojure.core/ns did not conform to spec.
 :data #:clojure.spec.alpha{:problems ({:path [:ns-clauses :refer-clojure :clause], :pred #{:refer-clojure}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-refer-clojure :clojure.core.specs.alpha/ns-refer-clojure], :in [2 0]} {:path [:ns-clauses :require :clause], :pred #{:require}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-require :clojure.core.specs.alpha/ns-require], :in [2 0]} {:path [:ns-clauses :import :classes :class], :pred clojure.core/simple-symbol?, :val [javax.xml.crypto], :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/import-list], :in [2 1]} {:path [:ns-clauses :import :classes :package-list :classes], :reason Insufficient input, :pred clojure.core/simple-symbol?, :val (), :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/import-list :clojure.core.specs.alpha/package-list :clojure.core.specs.alpha/package-list], :in [2 1]} {:path [:ns-clauses :use :clause], :pred #{:use}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-use :clojure.core.specs.alpha/ns-use], :in [2 0]} {:path [:ns-clauses :refer :clause], :pred #{:refer}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-refer :clojure.core.specs.alpha/ns-refer], :in [2 0]} {:path [:ns-clauses :load :clause], :pred #{:load}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-load :clojure.core.specs.alpha/ns-load], :in [2 0]} {:path [:ns-clauses :gen-class :clause], :pred #{:gen-class}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-gen-class :clojure.core.specs.alpha/ns-gen-class], :in [2 0]}), :spec #object[clojure.spec.alpha$regex_spec_impl$reify__2509 0x61892d1b clojure.spec.alpha$regex_spec_impl$reify__2509@61892d1b], :value (saml20-clj.sp (:require [clojure.data.xml :as xml] [clojure.xml :refer [parse]] [ring.util.response :refer [redirect]] [clj-time.core :as ctime] [clj-time.coerce :refer [to-timestamp]] [hiccup.core :as hiccup] [saml20-clj.shared :as shared] [saml20-clj.xml :as saml-xml] [clojure.data.zip.xml :as zf]) (:import [javax.xml.crypto] [javax.xml.crypto.dsig XMLSignature XMLSignatureFactory] [javax.xml.crypto.dom] [org.apache.xml.security Init] [org.apache.xml.security.utils Constants ElementProxy] [org.apache.xml.security.transforms Transforms] [org.apache.xml.security.c14n Canonicalizer] [javax.xml.crypto.dsig.dom DOMValidateContext] [java.security] [javax.xml.parsers DocumentBuilderFactory] [org.w3c.dom Document] [org.w3c.dom NodeList]) (:gen-class)), :args (saml20-clj.sp (:require [clojure.data.xml :as xml] [clojure.xml :refer [parse]] [ring.util.response :refer [redirect]] [clj-time.core :as ctime] [clj-time.coerce :refer [to-timestamp]] [hiccup.core :as hiccup] [saml20-clj.shared :as shared] [saml20-clj.xml :as saml-xml] [clojure.data.zip.xml :as zf]) (:import [javax.xml.crypto] [javax.xml.crypto.dsig XMLSignature XMLSignatureFactory] [javax.xml.crypto.dom] [org.apache.xml.security Init] [org.apache.xml.security.utils Constants ElementProxy] [org.apache.xml.security.transforms Transforms] [org.apache.xml.security.c14n Canonicalizer] [javax.xml.crypto.dsig.dom DOMValidateContext] [java.security] [javax.xml.parsers DocumentBuilderFactory] [org.w3c.dom Document] [org.w3c.dom NodeList]) (:gen-class))}
 :via
 [{:type clojure.lang.Compiler$CompilerException
   :message Syntax error macroexpanding clojure.core/ns at (saml20_clj/sp.clj:1:1).
   :data #:clojure.error{:phase :macro-syntax-check, :line 1, :column 1, :source saml20_clj/sp.clj, :symbol clojure.core/ns}
   :at [clojure.lang.Compiler checkSpecs Compiler.java 6971]}
  {:type clojure.lang.ExceptionInfo
   :message Call to clojure.core/ns did not conform to spec.
   :data #:clojure.spec.alpha{:problems ({:path [:ns-clauses :refer-clojure :clause], :pred #{:refer-clojure}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-refer-clojure :clojure.core.specs.alpha/ns-refer-clojure], :in [2 0]} {:path [:ns-clauses :require :clause], :pred #{:require}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-require :clojure.core.specs.alpha/ns-require], :in [2 0]} {:path [:ns-clauses :import :classes :class], :pred clojure.core/simple-symbol?, :val [javax.xml.crypto], :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/import-list], :in [2 1]} {:path [:ns-clauses :import :classes :package-list :classes], :reason Insufficient input, :pred clojure.core/simple-symbol?, :val (), :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/import-list :clojure.core.specs.alpha/package-list :clojure.core.specs.alpha/package-list], :in [2 1]} {:path [:ns-clauses :use :clause], :pred #{:use}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-use :clojure.core.specs.alpha/ns-use], :in [2 0]} {:path [:ns-clauses :refer :clause], :pred #{:refer}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-refer :clojure.core.specs.alpha/ns-refer], :in [2 0]} {:path [:ns-clauses :load :clause], :pred #{:load}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-load :clojure.core.specs.alpha/ns-load], :in [2 0]} {:path [:ns-clauses :gen-class :clause], :pred #{:gen-class}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-gen-class :clojure.core.specs.alpha/ns-gen-class], :in [2 0]}), :spec #object[clojure.spec.alpha$regex_spec_impl$reify__2509 0x61892d1b clojure.spec.alpha$regex_spec_impl$reify__2509@61892d1b], :value (saml20-clj.sp (:require [clojure.data.xml :as xml] [clojure.xml :refer [parse]] [ring.util.response :refer [redirect]] [clj-time.core :as ctime] [clj-time.coerce :refer [to-timestamp]] [hiccup.core :as hiccup] [saml20-clj.shared :as shared] [saml20-clj.xml :as saml-xml] [clojure.data.zip.xml :as zf]) (:import [javax.xml.crypto] [javax.xml.crypto.dsig XMLSignature XMLSignatureFactory] [javax.xml.crypto.dom] [org.apache.xml.security Init] [org.apache.xml.security.utils Constants ElementProxy] [org.apache.xml.security.transforms Transforms] [org.apache.xml.security.c14n Canonicalizer] [javax.xml.crypto.dsig.dom DOMValidateContext] [java.security] [javax.xml.parsers DocumentBuilderFactory] [org.w3c.dom Document] [org.w3c.dom NodeList]) (:gen-class)), :args (saml20-clj.sp (:require [clojure.data.xml :as xml] [clojure.xml :refer [parse]] [ring.util.response :refer [redirect]] [clj-time.core :as ctime] [clj-time.coerce :refer [to-timestamp]] [hiccup.core :as hiccup] [saml20-clj.shared :as shared] [saml20-clj.xml :as saml-xml] [clojure.data.zip.xml :as zf]) (:import [javax.xml.crypto] [javax.xml.crypto.dsig XMLSignature XMLSignatureFactory] [javax.xml.crypto.dom] [org.apache.xml.security Init] [org.apache.xml.security.utils Constants ElementProxy] [org.apache.xml.security.transforms Transforms] [org.apache.xml.security.c14n Canonicalizer] [javax.xml.crypto.dsig.dom DOMValidateContext] [java.security] [javax.xml.parsers DocumentBuilderFactory] [org.w3c.dom Document] [org.w3c.dom NodeList]) (:gen-class))}
   :at [clojure.spec.alpha$macroexpand_check invokeStatic alpha.clj 705]}]