### PR TITLE
Remove malformed import statements for clojure 1.10

### DIFF
--- a/src/saml20_clj/sp.clj
+++ b/src/saml20_clj/sp.clj
@@ -8,15 +8,12 @@
             [saml20-clj.shared :as shared]
             [saml20-clj.xml :as saml-xml]
             [clojure.data.zip.xml :as zf])
-  (:import [javax.xml.crypto]
-           [javax.xml.crypto.dsig XMLSignature XMLSignatureFactory]
-           [javax.xml.crypto.dom]
+  (:import [javax.xml.crypto.dsig XMLSignature XMLSignatureFactory]
            [org.apache.xml.security Init]
            [org.apache.xml.security.utils Constants ElementProxy]
            [org.apache.xml.security.transforms Transforms]
            [org.apache.xml.security.c14n Canonicalizer]
            [javax.xml.crypto.dsig.dom DOMValidateContext]
-           [java.security]
            [javax.xml.parsers DocumentBuilderFactory]
            [org.w3c.dom Document]
            [org.w3c.dom NodeList])


### PR DESCRIPTION
This removes import statements that are not valid under 1.10. These are no-ops in versions older so this should not affect anything at all.

Under 1.10 there are some deps that need updating like medley and taoensso.encore but this can happen at a later date.

