### PR TITLE
JDK 9 - 11 compatibility (tested on JDK 8 - 11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: clojure
+jdk:
+  - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
 deploy:
   skip_cleanup: true
   provider: script

--- a/project.clj
+++ b/project.clj
@@ -4,16 +4,16 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :source-paths ["src"]
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clj-time "0.11.0"]
-                 [ring "1.4.0"]
-                 [org.apache.santuario/xmlsec "2.0.4"]
+  :dependencies [[clj-time "0.11.0"]
                  [compojure "1.5.0"]
-                 [org.opensaml/opensaml "2.6.4"]
-                 [org.clojure/data.xml "0.0.7"]
+                 [org.apache.santuario/xmlsec "2.0.4"]
+                 [org.clojure/clojure "1.8.0"]
                  [org.clojure/data.codec "0.1.0"]
+                 [org.clojure/data.xml "0.0.7"]
                  [org.clojure/data.zip "0.1.1"]
-                 [org.vlacs/helmsman "1.0.0-alpha5"]]
+                 [org.opensaml/opensaml "2.6.4"]
+                 [org.vlacs/helmsman "1.0.0-alpha5"]
+                 [ring "1.4.0"]]
   :pedantic :warn
   :profiles {:dev {:source-paths ["dev" "test"]
                    :dependencies [[org.clojure/tools.namespace "0.2.10"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :source-paths ["src"]
   :dependencies [[clj-time "0.11.0"]
-                 [compojure "1.5.0"]
+                 [compojure "1.5.0" :exclusions [ring/ring-core]] ;ring/ring-core is part of [ring] below
                  [org.apache.santuario/xmlsec "2.0.4"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/data.codec "0.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                    :dependencies [[org.clojure/tools.namespace "0.2.10"]
                                   [org.clojure/tools.nrepl "0.2.3"]
                                   [hiccup "1.0.5"]
-                                  [http-kit "2.1.18"]]}}
+                                  [http-kit "2.3.0"]]}}
   :repositories [["releases" {:url "https://clojars.org/repo"
                               :sign-releases false
                               :username :env


### PR DESCRIPTION
This change makes the project JDK 11 compatible.
In addition to check JDK compatibility the project build now does 4 runs using JDK 8, 9, 10, 11 instead of running on default TravisCI JDK which is 11 as of today.

**Problem:** after the latest merge the TravisCI build shows red. The best guess is that between last time the PR was built – an unreasonable time of 3 months ago – and it was merged TravisCI has changed defaults for JDK-based project to use JDK 11 instead of JDK 8. The project was not ready and the build was failing on JDK 11.

*Note:* Reviewing per-commit is advised since I am including one cleanup commit that was not needed in the end but was done and seemed worth keeping: https://github.com/kirasystems/saml20-clj/pull/9/commits/9a5db52c6d8574108cfc8f7c89b113c7f4cfa4f0 .