### PR TITLE
Bump dependencies for projects + move doc-builder attributes to project.clj (JDK 11)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,20 +4,23 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :source-paths ["src"]
-  :dependencies [[clj-time "0.11.0"]
-                 [compojure "1.5.0" :exclusions [ring/ring-core]] ;ring/ring-core is part of [ring] below
-                 [org.apache.santuario/xmlsec "2.0.4"]
-                 [org.clojure/clojure "1.8.0"]
-                 [org.clojure/data.codec "0.1.0"]
-                 [org.clojure/data.xml "0.0.7"]
-                 [org.clojure/data.zip "0.1.1"]
+  :dependencies [[clj-time "0.15.2"]
+                 [compojure "1.6.1" :exclusions [ring/ring-core]]
+                 [org.apache.santuario/xmlsec "2.1.4"]
+                 [org.clojure/clojure "1.10.1"]
+                 [org.clojure/data.codec "0.1.1"]
+                 [org.clojure/data.xml "0.0.8"]
+                 [org.clojure/data.zip "0.1.3"]
                  [org.opensaml/opensaml "2.6.4"]
-                 [org.vlacs/helmsman "1.0.0-alpha5"]
-                 [ring "1.4.0"]]
+                 [org.vlacs/helmsman "1.0.0"]]
+  :jvm-opts ["-Djdk.xml.entityExpansionLimit=2000"
+             "-Djdk.xml.totalEntitySizeLimit=100000"
+             "-Djdk.xml.maxParameterEntitySizeLimit=10000"
+             "-Djdk.xml.maxElementDepth=1000"]
   :pedantic :warn
   :profiles {:dev {:source-paths ["dev" "test"]
-                   :dependencies [[org.clojure/tools.namespace "0.2.10"]
-                                  [org.clojure/tools.nrepl "0.2.3"]
+                   :dependencies [[org.clojure/tools.namespace "0.3.1"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
                                   [hiccup "1.0.5"]
                                   [http-kit "2.3.0"]]}}
   :repositories [["releases" {:url "https://clojars.org/repo"

--- a/src/saml20_clj/xml.clj
+++ b/src/saml20_clj/xml.clj
@@ -30,10 +30,6 @@
     (.setFeature doc "http://xml.org/sax/features/external-general-entities" false)
     (.setFeature doc "http://xml.org/sax/features/external-parameter-entities" false)
     (.setFeature doc "http://apache.org/xml/features/nonvalidating/load-external-dtd" false)
-    (.setAttribute doc "http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit" "2000")
-    (.setAttribute doc "http://www.oracle.com/xml/jaxp/properties/totalEntitySizeLimit" "100000")
-    (.setAttribute doc "http://www.oracle.com/xml/jaxp/properties/maxParameterEntitySizeLimit" "10000")
-    (.setAttribute doc "http://www.oracle.com/xml/jaxp/properties/maxElementDepth" "100")
     (.setExpandEntityReferences doc false)
     (.newDocumentBuilder doc)))
 


### PR DESCRIPTION
Updated dependencies for JDK 11 support