### PR TITLE
[DEV-7932] Added type hints to prevent reflection

### DIFF
--- a/src/saml20_clj/shared.clj
+++ b/src/saml20_clj/shared.clj
@@ -191,7 +191,9 @@
 
 (defn get-certificate-b64 [keystore-filename keystore-password cert-alias]
   (when-let [ks (load-key-store keystore-filename keystore-password)]
-    (-> ks (.getCertificate cert-alias) (.getEncoded) b64/encode (String. "UTF-8"))))
+    (let [certificate (.getCertificate ^java.security.KeyStore ks ^String cert-alias)
+          encoded     (.getEncoded ^java.security.cert.Certificate certificate)]
+      (-> encoded b64/encode (String. "UTF-8")))))
 
 
 ;; https://www.purdue.edu/apps/account/docs/Shibboleth/Shibboleth_information.jsp

--- a/src/saml20_clj/sp.clj
+++ b/src/saml20_clj/sp.clj
@@ -190,9 +190,9 @@
     (Init/init)
     (ElementProxy/setDefaultPrefix Constants/SignatureSpecNS "")
     (let [ks (shared/load-key-store keystore-filename keystore-password)
-          private-key (.getKey ks key-alias (.toCharArray keystore-password))
-          cert (.getCertificate ks key-alias)
-          sig-algo (case (.getAlgorithm private-key)
+          private-key (.getKey ^java.security.KeyStore ks key-alias (.toCharArray keystore-password))
+          cert (.getCertificate ^java.security.KeyStore ks key-alias)
+          sig-algo (case (.getAlgorithm ^java.security.Key private-key)
                      "DSA" (case algorithm
                              :sha256 org.apache.xml.security.signature.XMLSignature/ALGO_ID_SIGNATURE_DSA_SHA256
                              org.apache.xml.security.signature.XMLSignature/ALGO_ID_SIGNATURE_DSA)


### PR DESCRIPTION
Because we are using Clojure 1.10.1 on JDK 11, this library will throw a couple of reflection warnings just like
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by clojure.lang.InjectedInvoker/0x0000000100229440 (...) to method sun.security.rsa.RSAPrivateCrtKeyImpl.getAlgorithm()
WARNING: Please consider reporting this to the maintainers of clojure.lang.InjectedInvoker/0x0000000100229440
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

This PR adds a couple of type hints to prevent reflection from happening. It doesn't remove them from everything in this library, but it's enough for our own usage. The other warnings are in `clojure.xml` namespace
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by clojure.lang.InjectedInvoker/0x0000000800231c40 (...) to method com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl.parse(org.xml.sax.InputSource,org.xml.sax.HandlerBase)
WARNING: Please consider reporting this to the maintainers of clojure.lang.InjectedInvoker/0x0000000800231c40
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```